### PR TITLE
fix: shade google gson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.aliyun.lindorm</groupId>
 	<artifactId>lindorm-tsdb-client</artifactId>
-	<version>1.0.4</version>
+	<version>1.0.5</version>
 	<packaging>jar</packaging>
 
 	<name>lindorm-tsdb-client</name>
@@ -289,6 +289,10 @@
 							</artifactSet>
 							<relocations>
 								<relocation>
+									<relocation>
+										<pattern>com.google.gson</pattern>
+										<shadedPattern>${shaded.package}.gson</shadedPattern>
+									</relocation>
 									<pattern>retrofit2</pattern>
 									<shadedPattern>${shaded.package}.retrofit2</shadedPattern>
 								</relocation>


### PR DESCRIPTION
修复用户本地使用gson库时出现的版本冲突问题